### PR TITLE
Added support for built-in formats in JSON Schema

### DIFF
--- a/nodes/JsonValidator/JsonValidator.node.ts
+++ b/nodes/JsonValidator/JsonValidator.node.ts
@@ -7,6 +7,7 @@ import {
 } from 'n8n-workflow';
 
 import Ajv, { type SchemaObject } from 'ajv';
+import addFormats from 'ajv-formats';
 
 export class JsonValidator implements INodeType {
 	description: INodeTypeDescription = {
@@ -44,6 +45,7 @@ export class JsonValidator implements INodeType {
 		 * Initiate AVJ
 		 */
 		const AJV = new Ajv();
+		addFormats(AJV);
 
 		// Get the JSON schema defined by the user
 		const scheme = this.getNodeParameter('scheme', 0, undefined, {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "preinstall": "npx only-allow pnpm",
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
-    "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials package.json",
-    "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes credentials package.json"
+    "format": "prettier nodes --write",
+    "lint": "eslint nodes package.json",
+    "lintfix": "eslint nodes package.json --fix",
+    "prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes package.json"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "n8n-workflow": "*"
   },
   "dependencies": {
-    "ajv": "^8.17.1"
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
     devDependencies:
       '@typescript-eslint/parser':
         specifier: ^7.15.0
@@ -165,6 +168,14 @@ packages:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -2180,6 +2191,10 @@ snapshots:
       acorn: 8.12.1
 
   acorn@8.12.1: {}
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv@6.12.6:
     dependencies:


### PR DESCRIPTION
This patch adds support for [built-in formats](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) described by modern JSON Schema specs.

It also fixes n8n startup crash caused by empty `JsonValidator.credentials.ts` file.